### PR TITLE
Fixed menu cursor & invalid Windows paths

### DIFF
--- a/src/states/loading.rs
+++ b/src/states/loading.rs
@@ -1,3 +1,5 @@
+use std::env::current_dir;
+
 use nalgebra as na;
 use amethyst::{
     prelude::*,
@@ -17,7 +19,6 @@ use amethyst::{
         Camera, ImageFormat, SpriteSheet, SpriteSheetFormat, Texture
     },
     window::ScreenDimensions,
-    utils::application_dir
 };
 use crate::graphics::{TintBox, ShapeRender, CircleMesh, QuadMesh, TriangleMesh};
 use crate::utils::{TanksSpriteSheet, SpawnsSpriteSheet, color::Colorscheme, color::ColorschemeSet};
@@ -222,7 +223,8 @@ fn init_camera(world: &mut World, dimensions: &ScreenDimensions) {
 }
 
 fn load_resources(world: &mut World) {
-    let config = application_dir("res/config").unwrap();
+    let config = current_dir().unwrap().join("res/config");
+
     let tank_config         = config::TankConfig    ::load(&config.join("tank.ron"      )).unwrap();
     let maze_config         = config::MazeConfig    ::load(&config.join("maze.ron"      )).unwrap();
     let beamer_config       = config::BeamerConfig  ::load(&config.join("beamer.ron"    )).unwrap();
@@ -252,7 +254,7 @@ fn load_colorschemes(world: &mut World, progress: &mut ProgressCounter) {
 
     // Unless someone puts a invalid file in the colors directory,
     // none of those `unwrap()`s may panic
-    let dir = application_dir("res/colors").unwrap();
+    let dir = current_dir().unwrap().join("res/colors");
     let paths = fs::read_dir(dir).unwrap();
 
     for path in paths {

--- a/src/states/mainmenu.rs
+++ b/src/states/mainmenu.rs
@@ -81,8 +81,8 @@ impl MainMenuState {
             let mut storage = world.system_data::<WriteStorage<Transform>>();
             let cursor_trans = storage.get_mut(self.cursor.unwrap()).unwrap();
             cursor_trans.set_translation_xyz(
-                trans.pixel_x() - 20.,
-                trans.pixel_y() + (trans.height / 2.),
+                55.,
+                trans.pixel_y(),
                 1.1,//trans.global_z(),
             );
         }


### PR DESCRIPTION
# Cursor:
- x pos is now constant (55),
- y pos is the same as the text's.

# Paths:
Getting executable's path now uses  std::env::current_dir, instead of amethyst::utils::application_dir, because it returns an invalid path on Windows.